### PR TITLE
Add Plugin Development Team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jenkinsci/project-stats-plugin-plugin-developers


### PR DESCRIPTION
Hi!

This change adds a `CODEOWNERS` file to ensure folks on the development team are notified about new contributions. For plugins generated today, this file is included [by default](https://github.com/jenkinsci/archetypes/blob/master/common-files/.github/CODEOWNERS).

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.jenkins.github.AddTeamToCodeowners